### PR TITLE
Fix relative paths access for mp3 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 let Afplay = require('afplay');
 let program = require('commander');
+let path = require('path');
 
 let player = new Afplay;
 
@@ -20,16 +21,16 @@ program
   .option('y, yunnastan, understand that')
   .parse(process.argv);
 
-if (program.big) player.play("./big.mp3");
-if (program.down) player.play("./down.mp3");
-if (program.exac) player.play("./exac.mp3");
-if (program.explo) player.play("./explo.mp3");
-if (program.finger) player.play("./fingerinthe.mp3");
-if (program.goin) player.play("./goindown.mp3");
-if (program.heavy) player.play("./heavyhit.mp3");
-if (program.horn) player.play("./horn.mp3");
-if (program.hustle) player.play("./hustleon.mp3");
-if (program.issues) player.play("./issues.mp3");
-if (program.lesgo) player.play("./lesgo.mp3");
-if (program.upintha) player.play("./upintha.mp3");
-if (program.yunnastan) player.play("./yunnstan.mp3");
+if (program.big) player.play(path.join(__dirname, "./big.mp3"));
+if (program.down) player.play(path.join(__dirname, "./down.mp3"));
+if (program.exac) player.play(path.join(__dirname, "./exac.mp3"));
+if (program.explo) player.play(path.join(__dirname, "./explo.mp3"));
+if (program.finger) player.play(path.join(__dirname, "./fingerinthe.mp3"));
+if (program.goin) player.play(path.join(__dirname, "./goindown.mp3"));
+if (program.heavy) player.play(path.join(__dirname, "./heavyhit.mp3"));
+if (program.horn) player.play(path.join(__dirname, "./horn.mp3"));
+if (program.hustle) player.play(path.join(__dirname, "./hustleon.mp3"));
+if (program.issues) player.play(path.join(__dirname, "./issues.mp3"));
+if (program.lesgo) player.play(path.join(__dirname, "./lesgo.mp3"));
+if (program.upintha) player.play(path.join(__dirname, "./upintha.mp3"));
+if (program.yunnastan) player.play(path.join(__dirname, "./yunnstan.mp3"));


### PR DESCRIPTION
They we're currently being accessed like ./file-name.mp3 but
that was relative to the directory the program was called in.
Instead it needs to be relative to the directory the file is in.

We can achieve this with the __dirname variable which gives us the
directory path of the current firectory that the file resides in.